### PR TITLE
Clear cached certification data on cache:clear

### DIFF
--- a/src/Certificationy/Bundle/TrainingBundle/Manager/CertificationManagerCache.php
+++ b/src/Certificationy/Bundle/TrainingBundle/Manager/CertificationManagerCache.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Certificationy\Bundle\TrainingBundle\Manager;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\FlushableCache;
+use Predis\Client;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+class CertificationManagerCache implements Cache, FlushableCache, CacheClearerInterface
+{
+    const CACHE_PREFIX = 'certification:';
+
+    /**
+     * @param Client $redis
+     */
+    public function __construct(Client $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    /**
+     * Fetches an entry from the cache.
+     *
+     * @param string $id The id of the cache entry to fetch.
+     *
+     * @return mixed The cached data or FALSE, if no cache entry exists for the given id.
+     */
+    public function fetch($id)
+    {
+        return $this->redis->get(self::CACHE_PREFIX . $id);
+    }
+
+    /**
+     * Tests if an entry exists in the cache.
+     *
+     * @param string $id The cache id of the entry to check for.
+     *
+     * @return boolean TRUE if a cache entry exists for the given cache id, FALSE otherwise.
+     */
+    public function contains($id)
+    {
+        return $this->redis->exists(self::CACHE_PREFIX . $id);
+    }
+
+    /**
+     * Puts data into the cache.
+     *
+     * @param string $id       The cache id.
+     * @param mixed  $data     The cache entry/data.
+     * @param int    $lifeTime The cache lifetime.
+     *                         If != 0, sets a specific lifetime for this cache entry (0 => infinite lifeTime).
+     *
+     * @return boolean TRUE if the entry was successfully stored in the cache, FALSE otherwise.
+     */
+    public function save($id, $data, $lifeTime = 0)
+    {
+        $this->redis->set(self::CACHE_PREFIX . $id, $data);
+    }
+
+    /**
+     * Deletes a cache entry.
+     *
+     * @param string $id The cache id.
+     *
+     * @return boolean TRUE if the cache entry was successfully deleted, FALSE otherwise.
+     */
+    public function delete($id)
+    {
+        $this->redis->del(self::CACHE_PREFIX . $id);
+    }
+
+    /**
+     * Retrieves cached information from the data store.
+     *
+     * The server's statistics array has the following values:
+     *
+     * - <b>hits</b>
+     * Number of keys that have been requested and found present.
+     *
+     * - <b>misses</b>
+     * Number of items that have been requested and not found.
+     *
+     * - <b>uptime</b>
+     * Time that the server is running.
+     *
+     * - <b>memory_usage</b>
+     * Memory used by this server to store items.
+     *
+     * - <b>memory_available</b>
+     * Memory allowed to use for storage.
+     *
+     * @since 2.2
+     *
+     * @return array|null An associative array with server's statistics if available, NULL otherwise.
+     */
+    public function getStats()
+    {
+        return null;
+    }
+
+    /**
+     * Flushes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     */
+    public function flushAll()
+    {
+        $this->redis->del(self::CACHE_PREFIX . '*');
+    }
+
+    /**
+     * Clears any caches necessary.
+     *
+     * @param string $cacheDir The cache directory.
+     */
+    public function clear($cacheDir)
+    {
+        $this->flushAll();
+    }
+}

--- a/src/Certificationy/Bundle/TrainingBundle/Resources/config/symfony2_certification.yml
+++ b/src/Certificationy/Bundle/TrainingBundle/Resources/config/symfony2_certification.yml
@@ -4,13 +4,20 @@ services:
         arguments:
             - @certy.certification.factory
             - @certy.certification.builder
-            - @snc_redis.default
+            - @certificationy.certification.manager_cache
             - @jms_serializer
             - @monolog.logger.certy
             - @certy.certification.context.builder
             - %certy_debug%
         calls:
             - [ "setBasePath", [ %certy_file_provider_root_dir% ] ]
+
+    certificationy.certification.manager_cache:
+        class: Certificationy\Bundle\TrainingBundle\Manager\CertificationManagerCache
+        arguments:
+            - @snc_redis.default
+        tags:
+            - { name: kernel.cache_clearer }
 
     certificationy.report.persister:
         class: Certificationy\Bundle\TrainingBundle\EventListener\StoreCertificationReportListener


### PR DESCRIPTION
Certification data is cached in redis but never cleaned. This addition
makes use of the kernel.cache_clearer dic tag and flushes the relevant
redis keys if cache:clear is invoked.

See http://symfony.com/doc/2.5/reference/dic_tags.html#kernel-cache-clearer