### PR TITLE
Sort categories by filename

### DIFF
--- a/src/Certificationy/Component/Certy/Provider/AbstractFileProvider.php
+++ b/src/Certificationy/Component/Certy/Provider/AbstractFileProvider.php
@@ -65,7 +65,7 @@ abstract class AbstractFileProvider extends AbstractProvider implements FileProv
         }
 
         $finder = new Finder();
-        $finder->files()->in($options['path']);
+        $finder->files()->in($options['path'])->sortByName();
 
         foreach ($finder as $file) {
             $this->loadFile($file, $certificationName);


### PR DESCRIPTION
Currently categories are randomly sorted by the finder. This introduces
a more deterministic order by name.

This allows sorting the categories using the filename and using free
category names.