### PR TITLE
Improved question provider system behavior

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,6 @@ tools:
     # Code Sniffer
     php_code_sniffer:
         enabled:              true
-        command:              phpcs
         config:
             standard:         PSR2
         filter:
@@ -22,7 +21,6 @@ tools:
     # Copy/Paste Detector
     php_cpd:
         enabled:              true
-        command:              phpcpd
         excluded_dirs:
             - 'bin/*'
             - 'vendor/*'
@@ -31,7 +29,6 @@ tools:
     # PHP CS Fixer (http://http://cs.sensiolabs.org/).
     php_cs_fixer:
         enabled:              true
-        command:              php-cs-fixer
         config:
             level:            all
         filter:
@@ -43,7 +40,6 @@ tools:
     # Analyzes the size and structure of a PHP project.
     php_loc:
         enabled:              true
-        command:              phploc
         excluded_dirs:
             - bin
             - vendor
@@ -53,7 +49,6 @@ tools:
     # PHP Mess Detector (http://phpmd.org).
     php_mess_detector:
         enabled:              true
-        command:              phpmd
         filter:
             excluded_paths:
                 - 'bin/*'
@@ -64,7 +59,6 @@ tools:
     # Analyzes the size and structure of a PHP project.
     php_pdepend:
         enabled:              true
-        command:              pdepend
         excluded_dirs:
             - bin
             - vendor

--- a/src/Certificationy/Bundle/TrainingBundle/Manager/CertificationManager.php
+++ b/src/Certificationy/Bundle/TrainingBundle/Manager/CertificationManager.php
@@ -107,7 +107,13 @@ class CertificationManager
         if (!$this->cache->contains(self::$CACHE_KEY_CERTIFICATIONS)) {
 
             $finder = new Finder();
-            $files = $finder->files()->in($this->basePath.'/*')->name('context.yml');
+
+            try {
+                $files = $finder->files()->in($this->basePath.'/*')->name('context.yml');
+            } catch(\Exception $e) {
+                throw new \Exception('certificationy data folder seems to be empty or malformed.');
+            }
+
             $yaml = new Parser();
 
             $names = [];

--- a/src/Certificationy/Bundle/TrainingBundle/Twig/Extension/ContributingExtension.php
+++ b/src/Certificationy/Bundle/TrainingBundle/Twig/Extension/ContributingExtension.php
@@ -39,6 +39,10 @@ class ContributingExtension extends \Twig_Extension
      */
     public function addCertificationTemplateDir(CertificationManager $certificationManager)
     {
+        if (!is_dir($this->baseDir)) {
+            throw new \RuntimeException('certification-data folder not found: did you install the certifications ?');
+        }
+
         foreach (array_keys($certificationManager->getCertifications()) as $certificationName) {
             $this->loader->addPath($this->baseDir.'/'.$certificationName, $certificationName);
         }


### PR DESCRIPTION
I don't understand why, but the installation don't clone the repository "certificationy-data".

I just have a weird exception: I think it's better to return an explicit message in case the folder is missing or incomplete/malformed.

What do you think ?

Edit: Scrutinizer configuration was broken, I can make this commit in another pull request.
